### PR TITLE
refactor: change task grouping delimiter from colon to slash

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 [![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/tangent.taskasaurus?label=VS%20Code%20Marketplace&logo=visual-studio-code)](https://marketplace.visualstudio.com/items?itemName=tangent.taskasaurus)
 
-A VS Code extension that displays your tasks in the status bar for one-click launching. Perfect for repositories with many build, test, lint, and run tasks.
+Taskasaurus turns VS Code Tasks (think: saved CLI commands) into a one-click launcher strip in the status bar—so you can keep frequently used automations in your editor instead of context switching to the terminal. It also groups related tasks (like `Test/unit` / `Test/e2e`) to keep large task lists organized.
 
 ![Taskasaurus Demo](https://github.com/tangentlin/taskasaurus/raw/HEAD/docs/demo.gif)
 
 ## Features
 
 - **Status bar task launcher** - Tasks appear directly in the status bar for quick access
-- **Automatic grouping** - Tasks with colon-separated names (e.g., `Test: unit`, `Test: e2e`) are grouped together
+- **Automatic grouping** - Tasks with slash-separated names (e.g., `Test/unit`, `Test/e2e`) are grouped together
 - **Expandable groups** - Click a group to expand it, click again to collapse
 - **One-click execution** - Click any task to run it immediately
 - **Icon support** - Display icons next to your tasks using VS Code's built-in codicons
@@ -42,7 +42,7 @@ Once installed, Taskasaurus automatically displays your workspace tasks in the l
 
 ### Task Grouping
 
-Taskasaurus automatically groups tasks that share a common prefix separated by a colon. For example:
+Taskasaurus automatically groups tasks that share a common prefix separated by a slash. For example:
 
 ```json
 {
@@ -50,8 +50,8 @@ Taskasaurus automatically groups tasks that share a common prefix separated by a
   "tasks": [
     { "label": "Package", "type": "shell", "command": "npm run build" },
     { "label": "Run", "type": "shell", "command": "npm start" },
-    { "label": "Test: unit", "type": "shell", "command": "npm run test:unit" },
-    { "label": "Test: e2e", "type": "shell", "command": "npm run test:e2e" },
+    { "label": "Test/unit", "type": "shell", "command": "npm run test:unit" },
+    { "label": "Test/e2e", "type": "shell", "command": "npm run test:e2e" },
   ]
 }
 ```
@@ -60,7 +60,7 @@ This creates:
 
 - `Package` - standalone task
 - `Run` - standalone task
-- `Test` - expandable group containing `Test: unit` and `Test: e2e`
+- `Test` - expandable group containing `Test/unit` and `Test/e2e`
 
 > **Note:** Groups are only created when there are 2 or more tasks with the same prefix.
 
@@ -85,13 +85,13 @@ Add icons to your tasks using the `icon` property with any [VS Code codicon](htt
       "icon": { "id": "run" }
     },
     {
-      "label": "Test: unit",
+      "label": "Test/unit",
       "type": "shell",
       "command": "npm run test:unit",
       "icon": { "id": "beaker" }
     },
     {
-      "label": "Test: e2e",
+      "label": "Test/e2e",
       "type": "shell",
       "command": "npm run test:e2e",
       "icon": { "id": "compass" }
@@ -156,7 +156,7 @@ Taskasaurus provides these commands (accessible via Command Palette):
 ## Tips
 
 1. **Keep task labels short** - Status bar space is limited
-2. **Use consistent naming** - `Category: action` format works best for grouping
+2. **Use consistent naming** - `Category/action` format works best for grouping
 3. **Add icons** - Visual cues make tasks easier to identify at a glance
 4. **Hide background tasks** - Use `hide: true` for watchers and internal scripts
 

--- a/docs/specs.md
+++ b/docs/specs.md
@@ -35,10 +35,10 @@
 Given tasks:
 
 - `Build`
-- `Test: unit`
-- `Test: e2e`
-- `Check: lint`
-- `Check: style`
+- `Test/unit`
+- `Test/e2e`
+- `Check/lint`
+- `Check/style`
 - `Run`
 
 Collapsed:
@@ -52,8 +52,8 @@ Expanded(Test):
 
 - `Build`
 - `Test [disclosure]`
-- `childIcon  taskIcon?  Test: unit`
-- `childIcon  taskIcon?  Test: e2e`
+- `childIcon  taskIcon?  Test/unit`
+- `childIcon  taskIcon?  Test/e2e`
 - `Check [disclosure]`
 - `Run`
 
@@ -83,7 +83,7 @@ Status bar text supports codicons like `$(chevron-right)` and multiple icons. ([
 Tooltips:
 
 - Parent: “Expand group ‘Test’”
-- Child: “Run task ‘Test: unit’”
+- Child: "Run task 'Test/unit'"
 - Root leaf: “Run task ‘Build’”
 - Include `task.source` and workspace folder name in tooltip for multi-root disambiguation.
 
@@ -118,7 +118,7 @@ Use `vscode.tasks.fetchTasks()` to obtain all tasks available (including from pr
 Tasks may define a `"hide": true` property in `.vscode/tasks.json`. When a task is marked as hidden:
 
 - It **must not** appear in the status bar (neither as a root leaf, parent, nor child).
-- It **must not** contribute to group formation. For example, if `Test: unit` and `Test: e2e` both exist but `Test: e2e` has `hide: true`, no "Test" group is created since only one visible child remains.
+- It **must not** contribute to group formation. For example, if `Test/unit` and `Test/e2e` both exist but `Test/e2e` has `hide: true`, no "Test" group is created since only one visible child remains.
 - Hidden tasks are filtered out **before** the grouping algorithm runs.
 
 **Implementation:**
@@ -133,10 +133,10 @@ Tasks may define a `"hide": true` property in `.vscode/tasks.json`. When a task 
 
 Taskasaurus will create _virtual_ groups based on a delimiter in the task label:
 
-- Delimiter: first `:` (colon) in the label.
-- `GroupName = label.split(':', 1)[0].trim()`
-- If no `:`, task is a **root leaf**.
-- If `:` exists, task is a **candidate child** belonging to `GroupName`.
+- Delimiter: first `/` (slash) in the label.
+- `GroupName = label.split('/', 1)[0].trim()`
+- If no `/`, task is a **root leaf**.
+- If `/` exists, task is a **candidate child** belonging to `GroupName`.
 
 **When to create a group**
 
@@ -318,7 +318,7 @@ type ParentNode = {
 type ChildLeafNode = {
   id: NodeId;
   kind: "childLeaf";
-  label: string;          // full task label ("Test: unit")
+  label: string;          // full task label ("Test/unit")
   taskKey: TaskKey;
   iconId?: string;
 };
@@ -431,7 +431,7 @@ Behavior:
 
 ---
 
-If you want, I can also draft a **minimal `tasks.json` conventions guide** to encourage clean grouping (e.g., `Group: action` naming patterns), plus a set of recommended codicons for common task types (build/test/lint/run) using the official icon IDs. ([Visual Studio Code][2])
+If you want, I can also draft a **minimal `tasks.json` conventions guide** to encourage clean grouping (e.g., `Group/action` naming patterns), plus a set of recommended codicons for common task types (build/test/lint/run) using the official icon IDs. ([Visual Studio Code][2])
 
 [1]: https://vshaxe.github.io/vscode-extern/vscode/StatusBarItem.html?utm_source=chatgpt.com "vscode.StatusBarItem - Haxe externs for Visual Studio Code - API ..."
 [2]: https://code.visualstudio.com/api/references/icons-in-labels "Product Icon Reference | Visual Studio Code Extension

--- a/src/hierarchy.test.ts
+++ b/src/hierarchy.test.ts
@@ -28,7 +28,7 @@ describe("buildHierarchy", () => {
     expect(result).toEqual([]);
   });
 
-  it("creates root leaves for tasks without colons", () => {
+  it("creates root leaves for tasks without slashes", () => {
     const tasks = [mockTask("Build"), mockTask("Run")];
     const result = buildHierarchy(tasks, emptyIconMap);
 
@@ -40,12 +40,7 @@ describe("buildHierarchy", () => {
   });
 
   it("creates a group when 2+ tasks share a group name", () => {
-    const tasks = [
-      mockTask("Build"),
-      mockTask("Test: unit"),
-      mockTask("Test: e2e"),
-      mockTask("Run"),
-    ];
+    const tasks = [mockTask("Build"), mockTask("Test/unit"), mockTask("Test/e2e"), mockTask("Run")];
     const result = buildHierarchy(tasks, emptyIconMap);
 
     expect(result).toHaveLength(3); // Build, Test (parent), Run
@@ -56,13 +51,13 @@ describe("buildHierarchy", () => {
 
     if (testGroup?.kind === "parent") {
       expect(testGroup.children).toHaveLength(2);
-      expect(testGroup.children[0].label).toBe("Test: e2e");
-      expect(testGroup.children[1].label).toBe("Test: unit");
+      expect(testGroup.children[0].label).toBe("Test/e2e");
+      expect(testGroup.children[1].label).toBe("Test/unit");
     }
   });
 
-  it("does NOT create a group when only 1 task has a colon", () => {
-    const tasks = [mockTask("Build"), mockTask("Test: unit"), mockTask("Run")];
+  it("does NOT create a group when only 1 task has a slash", () => {
+    const tasks = [mockTask("Build"), mockTask("Test/unit"), mockTask("Run")];
     const result = buildHierarchy(tasks, emptyIconMap);
 
     expect(result).toHaveLength(3);
@@ -72,8 +67,8 @@ describe("buildHierarchy", () => {
   it("handles edge case: task label equals group name (runnable parent)", () => {
     const tasks = [
       mockTask("Test"), // exactly "Test"
-      mockTask("Test: unit"),
-      mockTask("Test: e2e"),
+      mockTask("Test/unit"),
+      mockTask("Test/e2e"),
     ];
     const result = buildHierarchy(tasks, emptyIconMap);
 
@@ -88,8 +83,8 @@ describe("buildHierarchy", () => {
       // The runnable task should appear at the top of children
       expect(testGroup.children).toHaveLength(3);
       expect(testGroup.children[0].label).toBe("Test");
-      expect(testGroup.children[1].label).toBe("Test: e2e");
-      expect(testGroup.children[2].label).toBe("Test: unit");
+      expect(testGroup.children[1].label).toBe("Test/e2e");
+      expect(testGroup.children[2].label).toBe("Test/unit");
     }
   });
 
@@ -101,15 +96,15 @@ describe("buildHierarchy", () => {
   });
 
   it("sorts group children alphabetically by full label", () => {
-    const tasks = [mockTask("Test: zebra"), mockTask("Test: alpha"), mockTask("Test: Beta")];
+    const tasks = [mockTask("Test/zebra"), mockTask("Test/alpha"), mockTask("Test/Beta")];
     const result = buildHierarchy(tasks, emptyIconMap);
 
     expect(result).toHaveLength(1);
     if (result[0].kind === "parent") {
       expect(result[0].children.map((c) => c.label)).toEqual([
-        "Test: alpha",
-        "Test: Beta",
-        "Test: zebra",
+        "Test/alpha",
+        "Test/Beta",
+        "Test/zebra",
       ]);
     }
   });
@@ -125,10 +120,10 @@ describe("buildHierarchy", () => {
   it("handles multiple groups correctly", () => {
     const tasks = [
       mockTask("Build"),
-      mockTask("Test: unit"),
-      mockTask("Test: e2e"),
-      mockTask("Check: lint"),
-      mockTask("Check: style"),
+      mockTask("Test/unit"),
+      mockTask("Test/e2e"),
+      mockTask("Check/lint"),
+      mockTask("Check/style"),
       mockTask("Run"),
     ];
     const result = buildHierarchy(tasks, emptyIconMap);

--- a/src/hierarchy.ts
+++ b/src/hierarchy.ts
@@ -20,11 +20,11 @@ type TaskInfo = {
 };
 
 function parseGroupName(label: string): string | undefined {
-  const colonIndex = label.indexOf(":");
-  if (colonIndex === -1) {
+  const slashIndex = label.indexOf("/");
+  if (slashIndex === -1) {
     return undefined;
   }
-  return label.substring(0, colonIndex).trim();
+  return label.substring(0, slashIndex).trim();
 }
 
 function getTaskIconId(task: vscode.Task, iconMap: IconMap): string | undefined {
@@ -60,7 +60,7 @@ export function buildHierarchy(tasks: vscode.Task[], iconMap: IconMap): RootNode
   }));
 
   // Step 2: Count how many tasks belong to each potential group
-  // Tasks with "Group: something" contribute to group "Group"
+  // Tasks with "Group/something" contribute to group "Group"
   const groupCounts = new Map<string, number>();
   for (const info of taskInfos) {
     if (info.groupName !== undefined) {
@@ -68,7 +68,7 @@ export function buildHierarchy(tasks: vscode.Task[], iconMap: IconMap): RootNode
     }
   }
 
-  // Step 3: Determine which groups are valid (2+ children with colons)
+  // Step 3: Determine which groups are valid (2+ children with slashes)
   const validGroups = new Set<string>();
   for (const [groupName, count] of groupCounts) {
     if (count >= 2) {
@@ -98,7 +98,7 @@ export function buildHierarchy(tasks: vscode.Task[], iconMap: IconMap): RootNode
 
   for (const info of taskInfos) {
     // Check if this task belongs to a valid group:
-    // 1. Has a groupName (colon prefix) that matches a valid group, OR
+    // 1. Has a groupName (slash prefix) that matches a valid group, OR
     // 2. Task label exactly matches a valid group name (exactMatchTasks)
     const belongsToGroup =
       (info.groupName !== undefined && validGroups.has(info.groupName)) ||
@@ -115,7 +115,7 @@ export function buildHierarchy(tasks: vscode.Task[], iconMap: IconMap): RootNode
       }
 
       // Check if task label equals group name exactly (runnable parent)
-      // This happens when label is exactly "Test" and we have "Test: unit", "Test: e2e"
+      // This happens when label is exactly "Test" and we have "Test/unit", "Test/e2e"
       if (info.label === groupName) {
         group.runnableTask = info;
       }
@@ -130,7 +130,7 @@ export function buildHierarchy(tasks: vscode.Task[], iconMap: IconMap): RootNode
       };
       group.children.push(childNode);
     } else {
-      // Root leaf: either no colon, or only one task with this group name
+      // Root leaf: either no slash, or only one task with this group name
       const rootLeaf: RootLeafNode = {
         id: generateNodeId("rootLeaf", info.taskKey),
         kind: "rootLeaf",

--- a/test-project/.vscode/tasks.json
+++ b/test-project/.vscode/tasks.json
@@ -14,13 +14,13 @@
       "icon": { "id": "run" }
     },
     {
-      "label": "Test: unit",
+      "label": "Test/unit",
       "type": "shell",
       "command": "npm run test:unit",
       "icon": { "id": "beaker" }
     },
     {
-      "label": "Test: e2e",
+      "label": "Test/e2e",
       "type": "shell",
       "command": "npm run test:e2e",
       "icon": { "id": "compass" }


### PR DESCRIPTION

## Summary

Changes the task grouping delimiter from `:` (colon) to `/` (slash) for a more intuitive hierarchy. The slash character is universally associated with paths and hierarchical structures (file paths, URLs, breadcrumbs), making `Test/unit` more natural to read than `Test: unit`. This also avoids conflicts with VS Code's own task source notation (e.g., `npm: build`) and common colon usages in task names.

## Key Changes

- Updated `parseGroupName()` in hierarchy.ts to split on `/` instead of `:`
- Updated all documentation and examples in specs.md and README.md to use the new `Category/action` format
- Updated test cases and test project tasks.json to reflect the new delimiter
