### PR TITLE
feat: add run feedback indicators to status bar

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,26 +2,6 @@
 
 Future features under consideration, roughly ordered by priority.
 
-## Run feedback indicators
-
-Show visual feedback in the status bar while tasks are running and after completion.
-
-**Behavior:**
-
-- When a task starts: prefix with `$(loading~spin)` (animated spinner)
-- On successful completion (exit code 0): show `$(check)` for 2 seconds
-- On failure (non-zero exit code): show `$(error)` for 2 seconds
-
-**Implementation notes:**
-
-- Use `vscode.tasks.onDidEndTaskProcess` to capture exit codes
-- Track only the most recently launched task to avoid status bar clutter
-- Feedback is optional enhancement; task execution works regardless
-
-**Why:**
-
-Users get immediate visual confirmation without switching to the terminal panel to check if a build succeeded or failed.
-
 ## Custom delimiter configuration
 
 Allow users to configure the grouping delimiter instead of hardcoding `:`.

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -126,7 +126,23 @@ This is the implementation plan for the Taskasaurus VS Code extension described 
 - Tasks with `"hide": true` in `tasks.json` do not appear in the status bar.
 - Group formation correctly accounts for hidden tasks (groups dissolve if < 2 visible children).
 
-### M7 — QA + packaging
+### M7 — Run feedback indicators
+
+- Track running tasks via `vscode.tasks.onDidStartTaskProcess`.
+- Show `$(loading~spin)` prefix on the task's status bar item while running.
+- On task completion (`onDidEndTaskProcess`):
+  - Exit code 0: show `$(check)` for 2 seconds.
+  - Non-zero exit code: show `$(error)` for 2 seconds.
+- Store feedback state per task (keyed by `TaskKey`) to support concurrent executions.
+- After feedback timeout, revert to normal label.
+
+**Done when**
+
+- Running tasks display spinner animation.
+- Completed tasks show success/error icon briefly before reverting.
+- Multiple concurrent tasks each show their own feedback state.
+
+### M8 — QA + packaging
 
 - Manual QA checklist (based on `docs/specs.md` acceptance criteria):
   - Collapsed/expanded behavior
@@ -136,6 +152,7 @@ This is the implementation plan for the Taskasaurus VS Code extension described 
   - Multi-root disambiguation
   - Works with both `tasks.json` tasks and provider tasks
   - Hidden tasks (`"hide": true`) do not appear and do not affect grouping
+  - Run feedback indicators (spinner, check, error)
 - Package the extension (e.g., with `vsce`) and install locally for verification.
 
 **Done when**
@@ -144,5 +161,4 @@ This is the implementation plan for the Taskasaurus VS Code extension described 
 
 ## Open questions / follow-ups
 
-- Whether to include “run feedback” (spinning / check / error) in v1, or defer to v1.1.
 - How to robustly extract runtime task icons across VS Code versions/providers (may require experimentation).

--- a/src/statusBar.ts
+++ b/src/statusBar.ts
@@ -1,13 +1,13 @@
 import * as vscode from "vscode";
 import type { RootNode, NodeId, UIState } from "./types";
-import { buildVisibleItems, COMMAND_ID } from "./statusBarModel";
+import { buildVisibleItems, COMMAND_ID, FeedbackMap } from "./statusBarModel";
 
 export class StatusBarRenderer {
   private items: vscode.StatusBarItem[] = [];
   private nodeIdToItem = new Map<NodeId, vscode.StatusBarItem>();
 
-  render(roots: RootNode[], uiState: UIState): void {
-    const visibleItems = buildVisibleItems(roots, uiState);
+  render(roots: RootNode[], uiState: UIState, feedbackMap: FeedbackMap = new Map()): void {
+    const visibleItems = buildVisibleItems(roots, uiState, feedbackMap);
 
     // Reconcile: reuse existing items where possible
     const newNodeIdToItem = new Map<NodeId, vscode.StatusBarItem>();

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,3 +42,10 @@ export type UIState = {
   lastInteractionAt?: number;
   collapseTimer?: ReturnType<typeof setTimeout>;
 };
+
+export type TaskFeedbackState = "running" | "success" | "error";
+
+export type TaskFeedback = {
+  state: TaskFeedbackState;
+  timer?: ReturnType<typeof setTimeout>;
+};


### PR DESCRIPTION

## Summary

Add visual feedback indicators in the status bar showing task execution state. When a task
runs, a spinner icon appears; on completion, a check (success) or error icon displays for
2 seconds before reverting. This gives users immediate visual confirmation of task outcomes
without needing to check the terminal panel.

## Key Changes

- Add `TaskFeedback` types and `FeedbackMap` to track running/success/error state per task
- Subscribe to `onDidStartTaskProcess` and `onDidEndTaskProcess` events in the controller
  to update feedback state with auto-clearing 2-second timers
- Update status bar label composition to prefix feedback icons (`$(loading~spin)`,
  `$(check)`, `$(error)`) that take precedence over task icons
