### PR TITLE
fix: remove tinted text on expanded children (low contrast)

### DIFF
--- a/docs/features/accordion-expansion.md
+++ b/docs/features/accordion-expansion.md
@@ -31,11 +31,10 @@ A single parent shows `$(chevron-down)` and its children are inserted directly a
 
 ### Sub-list Boundary Cues
 
-To make the start and end of an expanded sub-list obvious without adding intrusive widgets, the rendered group carries two subtle visual cues:
+To make the end of an expanded sub-list obvious without adding intrusive widgets, the rendered group carries two cues:
 
-- **Tinted children.** Every expanded child is rendered with the `disabledForeground` theme color, producing a softer/dimmer tone vs. the default status bar foreground (themes reliably set `disabledForeground` to a contrasting muted value). Parent, root-leaf, and divider items keep the default (bright) color, so the group reads as a tinted band sandwiched between normally-colored neighbors.
-- **Trailing divider item.** A standalone `│` item is emitted immediately after the last revealed child, sitting in the priority gap between that child and the next root. The bright vertical bar against the dim children punctuates the boundary between the sub-list and the next root item. The divider's click target is the parent's nodeId, so clicking it collapses the group (a free affordance via the existing parent click handler). Its tooltip reads `End of 'GroupName'`. During the expand stagger, the divider trails the currently-last-visible child.
-- **Optional leading arrow on children.** By default each expanded child is prefixed with `$(arrow-small-right)` to reinforce its child status. Users who find this visually noisy can set `taskasaurus.showChildIndicator` to `false` — the muted text color and trailing divider still distinguish children from root items, so the structure remains legible without the per-row arrow.
+- **Trailing divider item.** A standalone `│` item is emitted immediately after the last revealed child, sitting in the priority gap between that child and the next root. The vertical bar punctuates the boundary between the sub-list and the next root item. The divider's click target is the parent's nodeId, so clicking it collapses the group (a free affordance via the existing parent click handler). Its tooltip reads `End of 'GroupName'`. During the expand stagger, the divider trails the currently-last-visible child.
+- **Optional leading arrow on children.** By default each expanded child is prefixed with `$(arrow-small-right)` to reinforce its child status. Users who find this visually noisy can set `taskasaurus.showChildIndicator` to `false` — the trailing divider still marks where the sub-list ends.
 
 ### Transitions
 

--- a/docs/modules/status-bar.md
+++ b/docs/modules/status-bar.md
@@ -28,7 +28,6 @@ Manages the pool of VS Code status bar items and computes their labels, tooltips
 - `render()`: calls `buildVisibleItems()` to get the desired state, then reconciles:
   - Reuses existing items by `nodeId` when priority has not changed.
   - Recreates items when priority changes (priority is read-only after `createStatusBarItem()`).
-  - Sets `item.color` to `new vscode.ThemeColor("disabledForeground")` when `VisibleItem.tinted` is true, otherwise resets to `undefined`. The reset matters during reconciliation: a reused item that was a tinted child in the previous render must drop its color when it becomes a non-child (e.g., on collapse).
   - Disposes items no longer present in the visible set.
 - `dispose()`: disposes all status bar items and clears internal maps.
 
@@ -36,7 +35,7 @@ Manages the pool of VS Code status bar items and computes their labels, tooltips
 
 Pure functions with no VS Code runtime dependency (testable without the extension host):
 
-- `buildVisibleItems(roots, uiState, feedbackMap?, shortLabelConfig?, showChildIndicator = true)`: iterates root nodes, emits a `VisibleItem` per visible node. When a parent is expanded (`uiState.expandedGroupId === node.id`), emits child items immediately after it, then a trailing **divider item** that marks the end of the sub-list. Child items carry `tinted: true`; the divider does not (it's intentionally rendered in the default bright foreground so it stands out as a boundary against the dim children). The divider's `nodeId` is `divider::<parentId>`, its label is `│` (U+2502 BOX DRAWINGS LIGHT VERTICAL), and its `commandArgs.nodeId` points back to the parent so clicking it toggles collapse via the existing parent click handler. Its priority is `lastChildPriority - 1` so it sits between the last child and the next root in the status bar. The optional `showChildIndicator` flag (read from `taskasaurus.showChildIndicator`, default `true`) is forwarded to `composeChildLeafLabel` to toggle the leading `$(arrow-small-right)` on each child.
+- `buildVisibleItems(roots, uiState, feedbackMap?, shortLabelConfig?, showChildIndicator = true)`: iterates root nodes, emits a `VisibleItem` per visible node. When a parent is expanded (`uiState.expandedGroupId === node.id`), emits child items immediately after it, then a trailing **divider item** that marks the end of the sub-list. The divider's `nodeId` is `divider::<parentId>`, its label is `│` (U+2502 BOX DRAWINGS LIGHT VERTICAL), and its `commandArgs.nodeId` points back to the parent so clicking it toggles collapse via the existing parent click handler. Its priority is `lastChildPriority - 1` so it sits between the last child and the next root in the status bar. The optional `showChildIndicator` flag (read from `taskasaurus.showChildIndicator`, default `true`) is forwarded to `composeChildLeafLabel` to toggle the leading `$(arrow-small-right)` on each child.
 - `computePriority()`: assigns priority bands so items sort correctly in the status bar. Root item `i` gets priority `10000 - i*100`. Child `j` under root `i` gets `10000 - i*100 - 50 - j`.
 - `composeParentLabel()`: formats `[feedbackIcon|taskIcon] Label $(chevron-right|chevron-down)`. Feedback icon takes precedence over task icon.
 - `composeRootLeafLabel()`: formats `[feedbackIcon|taskIcon] Label`.
@@ -67,12 +66,10 @@ flowchart LR
 
 | Type               | Location                | Description                                                                           |
 | ------------------ | ----------------------- | ------------------------------------------------------------------------------------- |
-| `VisibleItem`      | `src/statusBarModel.ts` | `{ nodeId, label, tooltip, priority, commandArgs, tinted? }`                          |
+| `VisibleItem`      | `src/statusBarModel.ts` | `{ nodeId, label, tooltip, priority, commandArgs }`                                   |
 | `ShortLabelConfig` | `src/statusBarModel.ts` | `{ globalDefault: boolean, delimiter: string, groupOverrides: Map<string, boolean> }` |
 | `FeedbackMap`      | `src/statusBarModel.ts` | `Map<string, TaskFeedback>`                                                           |
 | `COMMAND_ID`       | `src/statusBarModel.ts` | `"taskasaurus.clickNode"`                                                             |
-
-The optional `tinted` flag on `VisibleItem` is set to `true` on every expanded child. The renderer maps it to the `disabledForeground` `ThemeColor` so children read as a faintly muted band, framing the sub-list visually.
 
 ## Invariants and Failure Modes
 

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
           "type": "boolean",
           "default": true,
           "description": "Show the leading arrow on child items in expanded groups.",
-          "markdownDescription": "Show the leading arrow (`→`) on child items when a group is expanded.\n\nDisable this for a cleaner look — the muted text color and trailing divider still visually distinguish child items from root items.\n\n**Default:** `true`"
+          "markdownDescription": "Show the leading arrow (`→`) on child items when a group is expanded.\n\nDisable this for a cleaner look — the trailing divider still marks where the sub-list ends.\n\n**Default:** `true`"
         },
         "taskasaurus.autoCollapseTimeout": {
           "type": "integer",

--- a/src/statusBar.test.ts
+++ b/src/statusBar.test.ts
@@ -147,18 +147,6 @@ describe("buildVisibleItems", () => {
     expect(items[3].nodeId).toBe("divider::parent::Test");
   });
 
-  it("tints expanded children but leaves parent, divider, and root leaves untinted", () => {
-    const roots = [createParent("Test", ["Test: unit", "Test: e2e"]), createRootLeaf("Build")];
-    const uiState: UIState = { expandedGroupId: "parent::Test" };
-    const items = buildVisibleItems(roots, uiState);
-
-    expect(items[0].tinted).toBeUndefined(); // parent
-    expect(items[1].tinted).toBe(true); // child
-    expect(items[2].tinted).toBe(true); // child
-    expect(items[3].tinted).toBeUndefined(); // divider — bright so it reads as a boundary
-    expect(items[4].tinted).toBeUndefined(); // root leaf after group
-  });
-
   it("emits a trailing divider for a single-child group", () => {
     const roots = [createParent("Test", ["Test: only"])];
     const uiState: UIState = { expandedGroupId: "parent::Test" };

--- a/src/statusBar.ts
+++ b/src/statusBar.ts
@@ -39,7 +39,6 @@ export class StatusBarRenderer {
 
       item.text = vi.label;
       item.tooltip = vi.tooltip;
-      item.color = vi.tinted ? new vscode.ThemeColor("disabledForeground") : undefined;
       item.command = { command: COMMAND_ID, title: "", arguments: [vi.commandArgs] };
       item.show();
 

--- a/src/statusBarModel.ts
+++ b/src/statusBarModel.ts
@@ -15,10 +15,11 @@ export type VisibleItem = {
   tooltip: string;
   priority: number;
   commandArgs: { nodeId: string };
-  tinted?: boolean;
 };
 
 const COMMAND_ID = "taskasaurus.clickNode";
+const DIVIDER_LABEL = "│";
+const DIVIDER_NODE_PREFIX = "divider::";
 
 function getFeedbackIcon(feedback: TaskFeedback | undefined): string | undefined {
   if (!feedback) return undefined;
@@ -202,18 +203,16 @@ export function buildVisibleItems(
             ),
             priority: computePriority(i, j),
             commandArgs: { nodeId: child.id },
-            tinted: true,
           });
         }
         if (childCount > 0) {
-          // Divider sits between the last child and the next root item, marking the
-          // visual boundary of the expanded group. Clicking it toggles the parent
-          // (reuses the parent's click handler via commandArgs). Untinted so the
-          // bright vertical bar reads as a sharp boundary against the dim children.
+          // Divider sits between the last child and the next root, marking the visual
+          // boundary of the expanded group. Clicking it toggles the parent (reuses the
+          // parent's click handler via commandArgs).
           const lastChildPriority = computePriority(i, childCount - 1);
           items.push({
-            nodeId: `divider::${node.id}`,
-            label: "│",
+            nodeId: `${DIVIDER_NODE_PREFIX}${node.id}`,
+            label: DIVIDER_LABEL,
             tooltip: `End of '${node.label}'`,
             priority: lastChildPriority - 1,
             commandArgs: { nodeId: node.id },


### PR DESCRIPTION

Users on lighter VS Code themes reported the dimmed (`disabledForeground`) color on expanded
children was hard to read. The boundary band the tint provided was a nice-to-have, not a must —
the `│` divider after the last child still marks where the sub-list ends, and the optional
leading `→` still flags children.

## Key Changes

- Drop the `tinted` field from `VisibleItem` and stop applying a ThemeColor on expanded children
- Extract `DIVIDER_LABEL` and `DIVIDER_NODE_PREFIX` constants near `COMMAND_ID`
- Update tests and docs to remove tint mentions; divider and showChildIndicator setting unchanged
